### PR TITLE
snarkjs npm package update

### DIFF
--- a/ares-api/package-lock.json
+++ b/ares-api/package-lock.json
@@ -12055,9 +12055,8 @@
       }
     },
     "snarkjs": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/snarkjs/-/snarkjs-0.1.20.tgz",
-      "integrity": "sha512-tYmWiVm1sZiB44aIh5w/3HUaTntTUC4fv+CWs4rR0gfkt2KbHTpArOqZW++/Lxujrn9IypXVhdKVUr/eE6Hxfg==",
+      "version": "git+https://github.com/iden3/snarkjs.git#cb7a7491351016a69cf0589f9d1b14b034358a0c",
+      "from": "git+https://github.com/iden3/snarkjs.git",
       "requires": {
         "big-integer": "^1.6.43",
         "chai": "^4.2.0",

--- a/ares-api/package.json
+++ b/ares-api/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-react-hooks": "^1.7.0",
     "express": "^4.17.1",
     "mongodb": "^3.3.2",
-    "snarkjs": "^0.1.20",
+    "snarkjs": "git+https://github.com/iden3/snarkjs.git",
     "supertest": "^4.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
[snarkjs npm package](https://www.npmjs.com/package/snarkjs) is not updated (KimLeeOh bug not fixed yet), but the GitHub version is up to date ([PR merged](https://github.com/iden3/snarkjs/pull/40#issue-371486732)). In this PR, the npm points to the GitHub within the `./ares-api` directroy. 
To test in `./ares-api`:
`npm install https://github.com/iden3/snarkjs.git --save`
`circom circuits/poseidon.circom`
`npx snarkjs setup --protocol kimleeoh`
This should output correct `verification_key.json` and `proving_key.json` files.